### PR TITLE
fix: register soft-break as a core format when the formats option is set

### DIFF
--- a/packages/quill/src/core/utils/createRegistryWithFormats.ts
+++ b/packages/quill/src/core/utils/createRegistryWithFormats.ts
@@ -1,7 +1,15 @@
 import { Registry } from 'parchment';
 
 const MAX_REGISTER_ITERATIONS = 100;
-const CORE_FORMATS = ['block', 'break', 'cursor', 'inline', 'scroll', 'text'];
+const CORE_FORMATS = [
+  'block',
+  'break',
+  'cursor',
+  'inline',
+  'scroll',
+  'soft-break',
+  'text',
+];
 
 const createRegistryWithFormats = (
   formats: string[],

--- a/packages/quill/test/unit/core/utils/createRegistryWithFormats.spec.ts
+++ b/packages/quill/test/unit/core/utils/createRegistryWithFormats.spec.ts
@@ -16,6 +16,15 @@ describe('createRegistryWithFormats', () => {
     expect(registry.query('bold')).toBeFalsy();
   });
 
+  test('registers soft-break as a core format', () => {
+    // Block.insertAt materializes a soft-break blot for every
+    // SOFT_BREAK_CHARACTER (clipboard matchBreak, Keyboard.handleShiftEnter),
+    // regardless of the "formats" config, so the restricted registry must
+    // always carry it or those inserts throw ParchmentError.
+    const registry = createRegistryWithFormats(['bold'], globalRegistry, debug);
+    expect(registry.query('soft-break')).toBeTruthy();
+  });
+
   test('register specified formats', () => {
     const registry = createRegistryWithFormats(['bold'], globalRegistry, debug);
     expect(registry.query('cursor')).toBeTruthy();


### PR DESCRIPTION
Fixes #57

## Problem

When a Quill instance is created with the `formats` allow-list option, any soft break throws `ParchmentError: [Parchment] Unable to create soft-break blot`:

```js
const quill = new Quill('#editor', { formats: ['bold'] });
quill.clipboard.dangerouslyPasteHTML('<p>alpha<br>beta</p>'); // throws
quill.insertText(0, '\u2028'); // Shift+Enter path — also throws
```

`Block.insertAt` materializes a `soft-break` blot for every `SOFT_BREAK_CHARACTER` segment, and both the clipboard's `matchBreak` and `Keyboard.handleShiftEnter` produce that character regardless of configuration — so the blot is structurally required, like `break`. But `createRegistryWithFormats` did not include it in `CORE_FORMATS`, so the restricted registry built for the `formats` option cannot create it. Apps using the default global registry are unaffected, which is why the demos don't show it.

## Fix

Add `'soft-break'` to `CORE_FORMATS`, with a regression test in `createRegistryWithFormats.spec.ts` asserting the restricted registry can always resolve `soft-break`.

We hit this in production (paste lost + unhandled exception on every affected paste) and are shipping the same one-liner as a patch against 2.2.6 in the meantime.

🤖 Drafted with [Claude Code](https://claude.com/claude-code)
